### PR TITLE
Rename deps

### DIFF
--- a/bin/lrpmctl
+++ b/bin/lrpmctl
@@ -53,9 +53,9 @@ if (empty($request)) {
 
 probeForAutoloader($progname);
 
-use TIPC\FileSystemUtils;
-use TIPC\SocketStreamClient;
-use TIPC\UnixDomainSocketAddress;
+use SimpleIPC\SyMPLib\FileSystemUtils;
+use SimpleIPC\SyMPLib\SocketStreamClient;
+use SimpleIPC\SyMPLib\UnixDomainSocketAddress;
 use TextTableFormatter\Table;
 use TerminalPalette\AnsiSeq;
 use PHPLRPM\IPCUtilities;

--- a/bin/lrpmctl
+++ b/bin/lrpmctl
@@ -131,7 +131,7 @@ function statusResponseHandler(string $response, bool $color): void
         fwrite(STDERR, "Invalid response from lrpm daemon ({$e->getMessage()}): $response" . PHP_EOL);
         exit(EXIT_INVALID_RESPONSE);
     }
-    $ps = ps(pidsFromStatus($status), ['rss']);
+    $ps = ps(pidsFromStatus($status), ['%cpu', 'rss']);
     fwrite(STDOUT, renderStatusTable($status, $ps, $color)->__toString());
 }
 
@@ -179,12 +179,13 @@ function renderStatusTable(iterable $status, iterable $ps, bool $color): Table
     $header = [
         AnsiSeq::get('BOLD', $color) . 'ID'     . AnsiSeq::get('RESET', $color),
         AnsiSeq::get('BOLD', $color) . 'PID'    . AnsiSeq::get('RESET', $color),
+        AnsiSeq::get('BOLD', $color) . '%CPU'   . AnsiSeq::get('RESET', $color),
         AnsiSeq::get('BOLD', $color) . 'RSS'    . AnsiSeq::get('RESET', $color),
         AnsiSeq::get('BOLD', $color) . 'UPTIME' . AnsiSeq::get('RESET', $color),
         AnsiSeq::get('BOLD', $color) . 'START'  . AnsiSeq::get('RESET', $color),
         AnsiSeq::get('BOLD', $color) . 'NAME'   . AnsiSeq::get('RESET', $color)
     ];
-    $align = ['l', 'r', 'r', 'r', 'l', 'l'];
+    $align = ['l', 'r', 'r', 'r', 'r', 'l', 'l'];
     $output = [$header];
     $redNone = AnsiSeq::get('RED', $color) . 'none' . AnsiSeq::get('RESET', $color);
     $redNotAvailable = AnsiSeq::get('RED', $color) . 'n/a' . AnsiSeq::get('RESET', $color);
@@ -197,6 +198,7 @@ function renderStatusTable(iterable $status, iterable $ps, bool $color): Table
         $pid = $state['pid'] ?? null;
         if ($pid !== null && isset($ps[$pid])) {
             $pidFmt = AnsiSeq::get('GREEN', $color) . $pid . AnsiSeq::get('RESET', $color);
+            $pcpuFmt = $ps[$pid]['%cpu'];
             $rssFmt = $ps[$pid]['rss'];
             $startedAtDateTime = new DateTime();
             $startedAtDateTime->setTimestamp($startedAt);
@@ -210,7 +212,7 @@ function renderStatusTable(iterable $status, iterable $ps, bool $color): Table
                 $startedAtFmt = date('Y-m-d H:i:s', $state['restartAt']);
             }
         }
-        $output[] = [$id, $pidFmt, $rssFmt, $uptimeFmt, $startedAtFmt, $name];
+        $output[] = [$id, $pidFmt, $pcpuFmt, $rssFmt, $uptimeFmt, $startedAtFmt, $name];
     }
     return (new Table($output))->setAlignment($align);
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/vrza/php-tipc"
+            "url": "https://github.com/vrza/php-symplib"
         },
         {
             "type": "vcs",
@@ -34,9 +34,9 @@
         "ext-pcntl": "*",
         "ext-posix": "*",
         "ext-sockets": "*",
-        "vrza/array-with-secondary-keys": "dev-main",
-        "vrza/cardinal-collections": "dev-main",
-        "vrza/php-tipc": "dev-main",
+        "cardinal-collections/array-with-secondary-keys": "dev-main",
+        "cardinal-collections/cardinal-collections": "dev-main",
+        "simple-ipc/php-symplib": "dev-main",
         "vrza/terminal-palette": "dev-main",
         "vrza/text-table-formatter": "dev-main"
     },

--- a/src/ConfigurationMessageHandler.php
+++ b/src/ConfigurationMessageHandler.php
@@ -2,7 +2,7 @@
 
 namespace PHPLRPM;
 
-use TIPC\MessageHandler;
+use SimpleIPC\SyMPLib\MessageHandler;
 use PHPLRPM\Serialization\Serializer;
 use PHPLRPM\Serialization\SerializationException;
 

--- a/src/ConfigurationProcess.php
+++ b/src/ConfigurationProcess.php
@@ -4,9 +4,9 @@ namespace PHPLRPM;
 
 use Exception;
 use RuntimeException;
-use TIPC\FileSystemUtils;
-use TIPC\SocketStreamClient;
-use TIPC\UnixDomainSocketAddress;
+use SimpleIPC\SyMPLib\FileSystemUtils;
+use SimpleIPC\SyMPLib\SocketStreamClient;
+use SimpleIPC\SyMPLib\UnixDomainSocketAddress;
 use PHPLRPM\Serialization\Serializer;
 
 class ConfigurationProcess

--- a/src/ControlMessageHandler.php
+++ b/src/ControlMessageHandler.php
@@ -2,7 +2,7 @@
 
 namespace PHPLRPM;
 
-use TIPC\MessageHandler;
+use SimpleIPC\SyMPLib\MessageHandler;
 use PHPLRPM\Serialization\JSONSerializer;
 
 class ControlMessageHandler implements MessageHandler

--- a/src/MessageService.php
+++ b/src/MessageService.php
@@ -3,11 +3,11 @@
 namespace PHPLRPM;
 
 use RuntimeException;
-use TIPC\FileSystemUtils;
-use TIPC\MessageHandler;
-use TIPC\SocketData;
-use TIPC\SocketStreamsServer;
-use TIPC\UnixDomainSocketAddress;
+use SimpleIPC\SyMPLib\FileSystemUtils;
+use SimpleIPC\SyMPLib\MessageHandler;
+use SimpleIPC\SyMPLib\SocketData;
+use SimpleIPC\SyMPLib\SocketStreamsServer;
+use SimpleIPC\SyMPLib\UnixDomainSocketAddress;
 
 class MessageService
 {


### PR DESCRIPTION
- `TIPC` was renamed to `SyMPLib`
- `cardinal-collections` and `array-with-secondary-keys` vendor prefix was renamed to `cardinal-collections`
- added %CPU column to `lrpmctl status` output