### PR TITLE
Replaced direct stdout logging with simplogger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/vrza/terminal-palette"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/vrza/simplogger"
         }
     ],
     "require": {
@@ -38,7 +42,8 @@
         "cardinal-collections/cardinal-collections": "dev-main",
         "simple-ipc/php-symplib": "dev-main",
         "vrza/terminal-palette": "dev-main",
-        "vrza/text-table-formatter": "dev-main"
+        "vrza/text-table-formatter": "dev-main",
+        "vrza/simplogger": "dev-main"
     },
     "autoload": {
         "psr-4": {

--- a/src/ConfigurationMessageHandler.php
+++ b/src/ConfigurationMessageHandler.php
@@ -27,7 +27,7 @@ class ConfigurationMessageHandler implements MessageHandler
             $this->processManager->setNewConfig($config);
             return self::RESP_OK;
         } catch (SerializationException $e) {
-            fwrite(STDERR, 'Error deserializing configuration: ' . $e->getMessage() . PHP_EOL);
+            Log::getInstance()->error('Error deserializing configuration: ' . $e->getMessage());
             return self::RESP_EDESERIALIZE;
         }
     }

--- a/src/ConfigurationProcessManager.php
+++ b/src/ConfigurationProcessManager.php
@@ -37,7 +37,7 @@ class ConfigurationProcessManager
             $this->configProcessRetries = 0;
         } else {
             $backoff = min(2 ** $this->configProcessRetries, self::CONFIG_PROCESS_MAX_BACKOFF_SECONDS);
-            fwrite(STDERR, "==> Backing off on config process spawn (retry: {$this->configProcessRetries}, seconds: $backoff)" . PHP_EOL);
+            Log::getInstance()->info("==> Backing off on config process spawn (retry: {$this->configProcessRetries}, seconds: $backoff)");
             $this->configProcessRestartAt = $now + $backoff;
             $this->configProcessRetries++;
         }
@@ -49,7 +49,7 @@ class ConfigurationProcessManager
             return false;
         }
         if ($this->configProcessRetries > self::CONFIG_PROCESS_MAX_RETRIES) {
-            fwrite(STDERR, '==> Config process failed after ' . self::CONFIG_PROCESS_MAX_RETRIES . ' retries, giving up' . PHP_EOL);
+            Log::getInstance()->error('==> Config process failed after ' . self::CONFIG_PROCESS_MAX_RETRIES . ' retries, giving up');
             return null;
         }
         $now = time();
@@ -78,7 +78,7 @@ class ConfigurationProcessManager
 
     public function sendSignalToConfigProcess(int $signal): void
     {
-        fwrite(STDERR, "==> Sending signal $signal to config process with pid {$this->configProcessId}" . PHP_EOL);
+        Log::getInstance()->info("==> Sending signal $signal to config process with pid {$this->configProcessId}");
         posix_kill($this->configProcessId, $signal);
     }
 

--- a/src/ConfigurationValidator.php
+++ b/src/ConfigurationValidator.php
@@ -107,10 +107,9 @@ class ConfigurationValidator
             if ($validator->isValid()) {
                 $filtered[$jobId] = $validator->getConfig();
             } else {
-                fwrite(
-                    STDERR,
+                Log::getInstance()->error(
                     "Invalid configuration for job $jobId: " .
-                    (new JSONSerializer())->serialize($validator->getErrors()) . PHP_EOL
+                    (new JSONSerializer())->serialize($validator->getErrors())
                 );
             }
         }

--- a/src/Log.php
+++ b/src/Log.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PHPLRPM;
+
+use VladimirVrzic\Simplogger\Logger;
+use VladimirVrzic\Simplogger\StdoutLogger;
+
+class Log
+{
+    private static $instance;
+
+    public static function getInstance(): Logger
+    {
+        if (is_null(self::$instance)) {
+            self::$instance = new StdoutLogger(true, true);
+        }
+        return self::$instance;
+    }
+
+    public static function setInstance(Logger $instance): void
+    {
+        self::$instance = $instance;
+    }
+
+}

--- a/src/MessageService.php
+++ b/src/MessageService.php
@@ -25,7 +25,7 @@ class MessageService
             IPCUtilities::getSocketDirs()
         );
         if (is_null($controlSocketPath)) {
-            fwrite(STDERR, "==> Control messages disabled" . PHP_EOL);
+            Log::getInstance()->notice("==> Control messages disabled");
         } else {
             $socketsData[] = new SocketData(new UnixDomainSocketAddress($controlSocketPath), $controlMessageHandler);
         }
@@ -51,7 +51,7 @@ class MessageService
     public function startMessageListener(): void
     {
         if (!is_null($this->messageServer)) {
-            fwrite(STDOUT, '==> Starting message listener service' . PHP_EOL);
+            Log::getInstance()->info('==> Starting message listener service');
             $this->messageServer->listen();
         }
     }

--- a/src/ProcessUtilities.php
+++ b/src/ProcessUtilities.php
@@ -12,7 +12,7 @@ class ProcessUtilities
                 $results[$pid] = $status;
                 $exit_code = pcntl_wexitstatus($status);
                 $message = "Child with PID $pid exited with code $exit_code";
-                fwrite(STDOUT, $message . PHP_EOL);
+                Log::getInstance()->info($message);
             } elseif (pcntl_wifsignaled($status)) {
                 $results[$pid] = $status;
                 $signal = pcntl_wtermsig($status);
@@ -20,11 +20,11 @@ class ProcessUtilities
                 if ($signalName = self::signalName($signal)) {
                     $message .= " $signalName";
                 }
-                fwrite(STDOUT, $message . PHP_EOL);
+                Log::getInstance()->info($message);
             } elseif (self::stoppedOrContinued($pid, $status)) {
                 continue;
             } else {
-                fwrite(STDERR, sprintf("Unexpected status (0x%x) for child PID %d", $status, $pid) . PHP_EOL);
+                Log::getInstance()->error(sprintf("Unexpected status (0x%x) for child PID %d", $status, $pid));
             }
         }
         return $results;
@@ -34,7 +34,7 @@ class ProcessUtilities
     {
         if (pcntl_wifcontinued($status)) {
             $message = "Child with PID $pid continued with signal 18 SIGCONT";
-            fwrite(STDOUT, $message . PHP_EOL);
+            Log::getInstance()->info($message);
             return true;
         }
 
@@ -44,7 +44,7 @@ class ProcessUtilities
             if ($signalName = self::signalName($signal)) {
                 $message .= " $signalName";
             }
-            fwrite(STDOUT, $message . PHP_EOL);
+            Log::getInstance()->info($message);
             return true;
         }
 


### PR DESCRIPTION
```
2024-02-19T22:14:32.400+00:00 kolvir [lrpm] INFO ==> Supervisor caught SIGCHLD (17)
2024-02-19T22:14:32.400+00:00 kolvir [lrpm] INFO Child with PID 612923 terminated by signal 15 SIGTERM
2024-02-19T22:14:32.400+00:00 kolvir [lrpm] INFO Child with PID 612924 terminated by signal 15 SIGTERM
2024-02-19T22:14:32.400+00:00 kolvir [lrpm] INFO Child with PID 612925 terminated by signal 15 SIGTERM
2024-02-19T22:14:32.400+00:00 kolvir [lrpm] INFO Job 23 run time was too short, backing off for seconds: 2
2024-02-19T22:14:32.400+00:00 kolvir [lrpm] INFO 2024-02-19T22:14:32+00:00 Job 23 scheduled to restart at 2024-02-19T22:14:33+00:00
2024-02-19T22:14:32.401+00:00 kolvir [lrpm] INFO Unmarking job 23 as stopping
2024-02-19T22:14:32.401+00:00 kolvir [lrpm] INFO Job 42 run time was too short, backing off for seconds: 2
2024-02-19T22:14:32.401+00:00 kolvir [lrpm] INFO 2024-02-19T22:14:32+00:00 Job 42 scheduled to restart at 2024-02-19T22:14:33+00:00
2024-02-19T22:14:32.401+00:00 kolvir [lrpm] INFO Unmarking job 42 as stopping
2024-02-19T22:14:32.402+00:00 kolvir [lrpm] INFO Job 33 run time was too short, backing off for seconds: 2
2024-02-19T22:14:32.402+00:00 kolvir [lrpm] INFO 2024-02-19T22:14:32+00:00 Job 33 scheduled to restart at 2024-02-19T22:14:33+00:00
2024-02-19T22:14:32.402+00:00 kolvir [lrpm] INFO Unmarking job 33 as stopping
2024-02-19T22:14:32.402+00:00 kolvir [lrpm] INFO ==> Job workers terminated: 23, 42, 33
2024-02-19T22:14:32.402+00:00 kolvir [lrpm] INFO ==> Supervisor caught SIGCHLD (17)
2024-02-19T22:14:32.402+00:00 kolvir [lrpm] INFO ==> Supervisor caught SIGCHLD (17)
2024-02-19T22:14:32.402+00:00 kolvir [lrpm] INFO ==> lrpm shut down cleanly

```